### PR TITLE
Fix FastJet modulefile modification during fjcontrib install

### DIFF
--- a/recipes/fjcontrib/1.054.sh
+++ b/recipes/fjcontrib/1.054.sh
@@ -86,7 +86,7 @@ then
     # Modify the fastjet module to include fjcontrib version
     fjmodule="{{yasp_dir}}/software/modules/fastjet/${FASTJET_VERSION}"
 		# this is more generic - path independent...
-		fjmodule=$(module show fastjet -t | grep modules/fastjet | cut -d':' -f1)
+		fjmodule=$(module show fastjet 2>&1 | grep modules/fastjet | cut -d':' -f1)
     echo "[i] Saving fjcontrib version to ${fjmodule}"
     echo "setenv FJCONTRIB_VERSION ${version}" >> ${fjmodule}
 fi

--- a/recipes/fjcontrib/1.101.sh
+++ b/recipes/fjcontrib/1.101.sh
@@ -64,7 +64,7 @@ then
     # Modify the fastjet module to include fjcontrib version
     fjmodule="{{yasp_dir}}/software/modules/fastjet/${FASTJET_VERSION}"
 		# this is more generic - path independent...
-		fjmodule=$(module show fastjet -t | grep modules/fastjet | cut -d':' -f1)
+		fjmodule=$(module show fastjet 2>&1 | grep modules/fastjet | cut -d':' -f1)
     echo "[i] Saving fjcontrib version to ${fjmodule}"
     echo "setenv FJCONTRIB_VERSION ${version}" >> ${fjmodule}
 fi


### PR DESCRIPTION
`module show` outputs to stderr rather than stdout, so nothing is piped to `grep`. Modified to use Lmod's built-in `--location` to output just the modulefile location, and `--redirect` to send the `module show` output to stdout so the command substitution works properly.