### PR TITLE
Add precompiled ROOT option for Ubuntu 22.04

### DIFF
--- a/recipes/bundle/hepbase.sh
+++ b/recipes/bundle/hepbase.sh
@@ -78,7 +78,7 @@ function install_package()
 dry=""
 clean=""
 default=""
-opts="{{clean}} {{dry}} {{default}}"
+opts="{{clean}} {{dry}} {{default}} --yasp-define n_cores={{n_cores}}"
 selection="all"
 if [ "x{{select}}" != "xNone" ]; then
 	selection="{{select}}"
@@ -86,6 +86,8 @@ fi
 separator "installing hepbase modules"
 echo_info "selection is ${selection}"
 note "opts are ${opts}"
+
+rootspec=default
 
 # check what the current version of cmake is
 cmake_version=$(cmake --version | grep version | awk '{print $3}')
@@ -111,14 +113,13 @@ install_package ${selection} fjcontrib/mp 	False 		 	${opts} --workdir=${this_wo
 #install_package ${selection} jetflav/default 	False 										
 install_package ${selection} HepMC2/default 	True 			 	${opts} --workdir=${this_workdir} --prefix=${this_prefix} --opt version=2.06.11
 install_package ${selection} LHAPDF6/6.5.4 		True 			 	${opts} --workdir=${this_workdir} --prefix=${this_prefix} --opt version=6.5.5
-install_package ${selection} root/default 		True 			 	${opts} --workdir=${this_workdir} --prefix=${this_prefix} --opt version=6.36.00 n_cores=30
+install_package ${selection} root/{{rootspec}} 		True 			 	${opts} --workdir=${this_workdir} --prefix=${this_prefix} --opt version=6.36.00
 install_package ${selection} HepMC3/default 	True 			 	${opts} --workdir=${this_workdir} --prefix=${this_prefix} --opt version=3.3.1
 install_package ${selection} pythia8/default		 	True 			 	${opts} --workdir=${this_workdir} --prefix=${this_prefix} --opt version=8315
 install_package ${selection} roounfold/default 	True 			${opts} --workdir=${this_workdir} --prefix=${this_prefix} --opt version=3.0.5
 # install_package ${selection} roounfold/default 	True 			${opts} --workdir=${this_workdir} --prefix=${this_prefix} --opt version=2.1
 install_package ${selection} dpmjet/19.3.7 			True 			${opts} --workdir=${this_workdir} --prefix=${this_prefix} --opt version=19.3.7
 install_package ${selection} starlight/default 	True 			${opts} --workdir=${this_workdir} --prefix=${this_prefix} --opt clean_build=yes
-
 # sherpa wont work with fj 3.4.2 and lower version of fj wont work with new root (cxx17)
 # separator "sherpa" 
 # install_package sherpa/2.2.15 		True 			 ${opts} --workdir=${this_workdir} --prefix=${this_prefix} --opt version=2.2.15 

--- a/recipes/root/ubuntu22.04.module
+++ b/recipes/root/ubuntu22.04.module
@@ -1,0 +1,9 @@
+#%Module
+setenv ROOTSYS {{prefix}}
+setenv ROOT_DIR {{prefix}}
+setenv CLING_STANDARD_PCH none
+prepend-path PATH {{prefix}}/bin
+prepend-path DYLD_LIBRARY_PATH {{prefix}}/lib
+prepend-path LD_LIBRARY_PATH {{prefix}}/lib
+prepend-path PYTHONPATH {{prefix}}/lib
+prepend-path CPATH {{prefix}}/include

--- a/recipes/root/ubuntu22.04.sh
+++ b/recipes/root/ubuntu22.04.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+mkdir -p {{prefix}}
+cd {{prefix}}
+version=6.34.08
+# gcc version should be swapped for different Ubuntu versions
+root_bin=root_v{{version}}.Linux-ubuntu22.04-x86_64-gcc11.4.tar.gz
+url=https://root.cern/download/${root_bin}
+
+local_file={{prefix}}/${root_bin}
+{{yasp}} --download {{url}} --output ${local_file}
+download_code=$?
+tar zxf ${local_file} --strip-components 1
+extr_code=$?
+rm ${local_file}
+
+if [[ $extr_code -ne 0 || $download_code -ne 0 ]]; then exit 1; fi


### PR DESCRIPTION
- Implement an option to build a precompiled version of ROOT instead of building from source. Useful to significantly shorten the build times in particular cases. I've included only Ubuntu 22.04 for now (the OS for hiccup), and the build from source is still an available option. Install this precompiled version with `yasp -i root/ubuntu22.04` or build from source with the previous `yasp -i root/default`. You can also opt into the precompiled version when installing `bundle/hepbase` by doing `yasp -i bundle/hepbase --opt rootspec=ubuntu22.04`. Without `--opt` ROOT will build from source as usual.
- Fix the number of cores to be used not being propagated to the compilation of the individual packages when installing `bundle/hepbase` with, e.g. `yasp -mi bundle/hepbase --opt n_cores=5`. Using `--yasp-define` to attach the number of cores to each install step as a workaround instead of `--opt` here since `--opt` is already used in the `hepbase` recipes to define the versions.