### PR TITLE
Add interactive option to yaspenv

### DIFF
--- a/yaspenv.sh
+++ b/yaspenv.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
 
+interactive=
+while getopts "i" opt; do
+  	case $opt in
+		i)
+			interactive="yes"
+			;;
+		\?)
+			echo "Invalid option: -$OPTARG" >&2
+			exit 1
+			;;
+	esac
+done
+shift $(( OPTIND-1 ))
+
 savedir=${PWD}
 
 function thisdir()
@@ -97,8 +111,13 @@ if [ -d ${venvdir} ]; then
 		echo "[i] exec ${tmpfile}" >&2
 		echo "${cmnd}" >> ${tmpfile}
 		chmod +x ${tmpfile}
-		${tmpfile}
+		if [ -n "$interactive" ]; then
+			/bin/bash --init-file ${tmpfile} -i
+		else
+			${tmpfile}
+		fi
 	fi
+	ecode=$?
 	#-s < .activate
 fi
 
@@ -120,3 +139,4 @@ fi
 #fi
 
 cd ${savedir}
+exit $ecode


### PR DESCRIPTION
- Implement a simple interactive option `-i` to yaspenv when running a command. Can be useful to e.g. source additional aliases or load more packages before starting the interactive session.
- Fix a bug where `yaspenv.sh` would exit 0 even if the command run inside the environment failed due to the last `cd` command which typically succeeds.