### PR TITLE
Avoid distutils

### DIFF
--- a/src/yasp.py
+++ b/src/yasp.py
@@ -227,11 +227,11 @@ def get_python_lib_dir():
 
 def get_python_include_dir():
 		"""
-		Get the Python library directory using distutils.
+		Get the Python library directory using sysconfig.
 		"""
 		try:
-				from distutils.sysconfig import get_python_inc
-				return get_python_inc()
+				from sysconfig import get_path
+				return get_path('include')
 		except ImportError:
 				pass
 


### PR DESCRIPTION
`distutils` is deprecated since Python 3.10 and completely removed in 3.12. `sysconfig` is the better-supported way of getting the include directory (available since 3.2).